### PR TITLE
Fix deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 Demo project using RedwoodSDK with the [useAgentsChat](https://developers.cloudflare.com/agents/api-reference/agents-api/#chat-agent-react-api) react API from the Cloudflare [Agents](https://developers.cloudflare.com/agents/) SDK.
 
 > [!WARNING]
-> This repo is usig a v0.1.0-alpha pre-release  
-> The project currently only works in dev, but errors when deployed on cloudflare.  
-> https://rwsdk-use-agent-chat.jldec.workers.dev/
+> This repo is using a v0.1.0-alpha pre-release  
 
 See this rwsdk [discord thread](https://discord.com/channels/679514959968993311/1382133344011292712) for investigation and discussion.
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,18 +4,20 @@ import { useAgent } from 'agents/react'
 import { useAgentChat } from 'agents/ai-react'
 import type { Message } from '@ai-sdk/react'
 
-export default function App({ host }: { host?: string }) {
+export default function App() {
   const agent = useAgent({
     agent: 'chat-agent-do-namespace',
-    name: 'chat-agent-id',
-    host
+    name: 'chat-agent-id'
   })
 
   //  return <div>Hello World</div>
 
   const { messages, input, handleInputChange, handleSubmit, clearHistory } = useAgentChat({
     agent,
-    maxSteps: 5
+    maxSteps: 5,
+    // context(justinvdm): Avoid fetch() as side-effect of SSR render
+    // https://github.com/cloudflare/agents/blob/398c7f5411f3a63f450007f83db7e3f29b6ed4c2/packages/agents/src/ai-react.tsx#L85-L88
+    getInitialMessages: typeof window === 'undefined' ? null : undefined
   })
 
   return (

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -20,5 +20,5 @@ export default defineApp([
   // context(justinvdm): partysocket relies on `window.location.host` for client components.
   // This won't be set durin SSR, so we need to give it the host explicitly
   // https://github.com/cloudflare/partykit/blob/09c1d1c382252ec7a1c998a5f8faf4e7d6d2b484/packages/partysocket/src/react.ts#L25
-  render(Document, [index([({ request }) => <App host={new URL(request.url).host} />])])
+  render(Document, [index([App])])
 ])


### PR DESCRIPTION
## Problem
1. SSR render happens, `useAgentChat()` called
2. During that SSR, as a side-effect of rendering, `useAgentChat()` makes a `fetch()`: https://github.com/cloudflare/agents/blob/398c7f5411f3a63f450007f83db7e3f29b6ed4c2/packages/agents/src/ai-react.tsx#L85-L88
3. CF does not like this errors with that 1042
   * still understanding why - presumably something to do with `fetch()`-ing in a worker for that worker itself?
   
## Solution
Avoid fetching initial messages during SSR render by providing an option to `useAgentChat()`